### PR TITLE
Subíndices de elementos muestrales

### DIFF
--- a/notas/01-introduccion.Rmd
+++ b/notas/01-introduccion.Rmd
@@ -526,7 +526,7 @@ es suficientemente grande ( $m$ es grande ), entonces
 $$ \widehat{Err}(f) = \frac{1}{m} \sum_{i=1}^m L(\mathbf{y}^{(i)} , f(\mathbf{x}^{(i)})) \approx Err(f)$$
 **Observación**: nótese que para que este argumento funcione, la $f$ no puede
 depender de ninguna manera de los datos de prueba 
-$(\mathbf{x}^{(1)}, \mathbf{y}^{(1)}), (\mathbf{x}^{(1)}, \mathbf{y}^{(1)}), \ldots, (\mathbf{x}^{(m)}, \mathbf{y}^{(m)}),$ pues entonces tendríamos que tomar
+$(\mathbf{x}^{(1)}, \mathbf{y}^{(1)}), (\mathbf{x}^{(2)}, \mathbf{y}^{(2)}), \ldots, (\mathbf{x}^{(m)}, \mathbf{y}^{(m)}),$ pues entonces tendríamos que tomar
 el valor esperado promediando sobre $f$, y esta promedio **no** estima $Err(f)$
 
 


### PR DESCRIPTION
Se repite el subíndice 1 para las primeras dos parejas de datos muestrales