### PR TITLE
Corrección de sub-índices en estimación de betas

### DIFF
--- a/notas/02-descenso-gradiente.Rmd
+++ b/notas/02-descenso-gradiente.Rmd
@@ -766,11 +766,11 @@ $${g}_{\beta^s} (X) = \beta_0^s + \beta_1^s Z_1 + \beta_2^s Z_2 + \cdots + \beta
 
 Sustituyendo $Z_j = (X_j - \mu_j)/s_j,$ 
 
-$${g}_{\beta^s} (X) = (\beta_0^s - \sum_{j=1}^p \mu_j/s_j) + \frac{\beta_1^s}{s_j} X_1 + \frac{\beta_2^s}{s_2} X_2 + \cdots + \frac{\beta_p^s}{s_p} X_p,$$
+$${g}_{\beta^s} (X) = (\beta_0^s - \sum_{j=1}^p \beta_j^s \mu_j/s_j) + \frac{\beta_1^s}{s_j} X_1 + \frac{\beta_2^s}{s_2} X_2 + \cdots + \frac{\beta_p^s}{s_p} X_p,$$
 Y vemos que tiene la misma forma funcional de $f_\beta(X)$. Si la solución de mínimos cuadrados es única,
 entonces una vez que ajustemos tenemos que tener $\hat{f}_\beta(X) = \hat{g}_{\beta^s} (X)$,
 lo que implica que
-$$\hat{\beta}_0 = \hat{\beta}_0^s -  \sum_{j=1}^p \hat{\beta}_0^s\mu_j/s_j$$ y
+$$\hat{\beta}_0 = \hat{\beta}_0^s -  \sum_{j=1}^p \hat{\beta}_j^s\mu_j/s_j$$ y
 $$\hat{\beta}_j = \hat{\beta}_j^s/s_j.$$
 
 Nótese que para pasar del problema estandarizado al no estandarizado simplemente


### PR DESCRIPTION
Me parece que las betas se omitieron en el recálculo de beta 0 y unos renglones adelante el índice de beta j se confundió con beta 0